### PR TITLE
Fix Scheme string-append freezing

### DIFF
--- a/src/main/java/COM/sootNsmoke/scheme/SchemeLibrary.java
+++ b/src/main/java/COM/sootNsmoke/scheme/SchemeLibrary.java
@@ -1278,9 +1278,10 @@ class string_append extends CompiledProcedure
         Cons l = list;
         while(l != null)
         {
-            length += (list.car() instanceof String)
-                    ? ((String) list.car()).length()
-                    : ((Character[]) list.car()).length;
+            length += (l.car() instanceof String)
+                    ? ((String) l.car()).length()
+                    : ((Character[]) l.car()).length;
+            l = (Cons) l.cdr();
         }
         Character[] s = new Character[length];
         int n = 0;


### PR DESCRIPTION
The `string-append` procedure in the Scheme implementation freezes if given any parameters. This fixes it, but I'm not even sure which oolong repository is the definitive one, or which is maintained, or if there's something else I'm missing.